### PR TITLE
Add the reactComponent bindingHandler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,15 +62,14 @@
       "dev": true
     },
     "@types/knockout": {
-      "version": "3.4.53",
-      "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/@types/knockout/-/knockout-3.4.53.tgz",
-      "integrity": "sha1-PCWx1088KxNVfQ7LpKOK0MWudCk="
+      "version": "3.4.59",
+      "resolved": "https://registry.npmjs.org/@types/knockout/-/knockout-3.4.59.tgz",
+      "integrity": "sha512-uLVb9AWPnQajGE8QETNVS2qPpxTVzsWOWP9dLwBrqfIkatR3mCOoU3QP8idI4YDwRRxdTlYgfSeMFbUOjENvyw=="
     },
     "@types/node": {
       "version": "10.0.0",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/@types/node/-/node-10.0.0.tgz?dl=https://registry.npmjs.org/@types/node/-/node-10.0.0.tgz",
-      "integrity": "sha1-xA+OB9zmB9PvJaYmuTpqfNz5eIE=",
-      "dev": true
+      "integrity": "sha1-xA+OB9zmB9PvJaYmuTpqfNz5eIE="
     },
     "@types/react": {
       "version": "16.3.10",
@@ -78,6 +77,15 @@
       "integrity": "sha1-LyXu+D98f2xRzqTAJmD3J8ddOzM=",
       "requires": {
         "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.9.tgz",
+      "integrity": "sha512-4Z0bW+75zeQgsEg7RaNuS1k9MKhci7oQqZXxrV5KUGIyXZHHAAL3KA4rjhdH8o6foZ5xsRMSqkoM5A3yRVPR5w==",
+      "requires": {
+        "@types/node": "*",
+        "@types/react": "*"
       }
     },
     "abab": {
@@ -512,8 +520,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/asap/-/asap-2.0.6.tgz?dl=https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.3",
@@ -1599,7 +1606,6 @@
       "version": "0.1.12",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/encoding/-/encoding-0.1.12.tgz?dl=https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -1897,7 +1903,6 @@
       "version": "0.8.16",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/fbjs/-/fbjs-0.8.16.tgz?dl=https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-      "dev": true,
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -1911,8 +1916,7 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/core-js/-/core-js-1.2.7.tgz?dl=https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
     },
@@ -2863,8 +2867,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/iconv-lite/-/iconv-lite-0.4.19.tgz?dl=https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs=",
-      "dev": true
+      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
     },
     "import-local": {
       "version": "1.0.0",
@@ -3137,8 +3140,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/is-stream/-/is-stream-1.1.0.tgz?dl=https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-string": {
       "version": "1.0.4",
@@ -3201,7 +3203,6 @@
       "version": "2.2.1",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz?dl=https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -3715,8 +3716,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/js-tokens/-/js-tokens-3.0.2.tgz?dl=https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.11.0",
@@ -3939,7 +3939,6 @@
       "version": "1.3.1",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/loose-envify/-/loose-envify-1.3.1.tgz?dl=https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0"
       }
@@ -4164,7 +4163,6 @@
       "version": "1.7.3",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/node-fetch/-/node-fetch-1.7.3.tgz?dl=https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
-      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -4258,8 +4256,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/object-assign/-/object-assign-4.1.1.tgz?dl=https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -4656,7 +4653,6 @@
       "version": "7.3.1",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/promise/-/promise-7.3.1.tgz?dl=https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
-      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -4665,7 +4661,6 @@
       "version": "15.6.1",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/prop-types/-/prop-types-15.6.1.tgz?dl=https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
       "integrity": "sha1-NmREU1ZCVd3aORGR+zoSXL32VMo=",
-      "dev": true,
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.3.1",
@@ -4772,7 +4767,6 @@
       "version": "16.3.2",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/react-dom/-/react-dom-16.3.2.tgz?dl=https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
       "integrity": "sha1-y5DxB+CVNtaD2E7V1IiOlkDg5N8=",
-      "dev": true,
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
@@ -5462,8 +5456,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/setimmediate/-/setimmediate-1.0.5.tgz?dl=https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -6438,8 +6431,7 @@
     "ua-parser-js": {
       "version": "0.7.17",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/ua-parser-js/-/ua-parser-js-0.7.17.tgz?dl=https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha1-6exflJi57JEOeuOsYmqAXE0J7Kw=",
-      "dev": true
+      "integrity": "sha1-6exflJi57JEOeuOsYmqAXE0J7Kw="
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -6688,8 +6680,7 @@
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://purecloud.artifactoryonline.com/purecloud/api/npm/inin-internal-npm/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz?dl=https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha1-3eal3zFfnTmZGqF2IYU9cguFVm8=",
-      "dev": true
+      "integrity": "sha1-3eal3zFfnTmZGqF2IYU9cguFVm8="
     },
     "whatwg-mimetype": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   "author": "Retsam19",
   "license": "ISC",
   "dependencies": {
-    "@types/knockout": "^3.4.53",
-    "@types/react": "^16.3.10"
+    "@types/knockout": "^3.4.58",
+    "@types/react-dom": "^16.0.6",
+    "@types/react": "^16.3.10",
+    "react-dom": "^16.3.2"
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.10",
@@ -25,7 +27,6 @@
     "jest": "^22.4.3",
     "knockout": "3.x",
     "react": "16.x",
-    "react-dom": "^16.3.2",
     "rollup": "^0.58.2",
     "rollup-plugin-typescript2": "^0.13.0",
     "ts-jest": "^22.4.4",

--- a/src/bindingHandlers/reactComponent.ts
+++ b/src/bindingHandlers/reactComponent.ts
@@ -1,0 +1,52 @@
+import ko from "knockout";
+import React, { ComponentClass } from "react";
+import ReactDOM from "react-dom";
+
+export interface ReactComponentBindingValue {
+    Component: ComponentClass;
+    props: any;
+}
+
+const bindingHandler: KnockoutBindingHandler<HTMLElement, ReactComponentBindingValue> = {
+    init(element) {
+        ko.utils.domNodeDisposal.addDisposeCallback(element, () => ReactDOM.unmountComponentAtNode(element));
+        return { controlsDescendantBindings: true };
+    },
+    /**
+     * The main logic goes into update so that it will properly rerender if an observable is read inside the data-bind
+     */
+    update(element, valueAccessor) {
+        const { props, Component } = ko.toJS(valueAccessor());
+        if(!Component) {
+            throw new Error("No component provided to reactComponent bindingHandler");
+        }
+        ReactDOM.render(React.createElement(Component, props), element);
+    },
+};
+
+const noop = (() => {/* noop */});
+const registrars = {
+    register() {
+        ko.bindingHandlers.reactComponent = bindingHandler;
+    },
+    registerShorthandSyntax(bindingHandlerName = "reactComponent") {
+        const existingPreprocessNode = (ko.bindingProvider.instance as any).preprocessNode || noop;
+        (ko.bindingProvider.instance as any).preprocessNode = function(node: Node) {
+            if (node.nodeType === 8) {
+                const match = node.nodeValue!.match(/^\s*react\s*:\s*([\w\.]+)\s+((.|\n)+?)\s*$/);
+                if (match) {
+                    const div = document.createElement("div");
+                    const [ /* wholeMatch */, Component, props ] = match; // tslint:disable-line variable-name
+                    div.dataset.bind = `${bindingHandlerName}: { Component: ${Component}, props: ${props} }`;
+                    node.parentNode!.replaceChild(div, node);
+
+                    // Tell Knockout about the new nodes so that it can apply bindings to them
+                    return [div];
+                }
+            }
+            return existingPreprocessNode(node);
+        };
+    },
+};
+
+export default { ...bindingHandler, ...registrars};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export {default as observe} from "./observe";
+export {default as reactComponentBindingHandler} from "./bindingHandlers/reactComponent";

--- a/tests/bindingHandlers/reactComponent.test.tsx
+++ b/tests/bindingHandlers/reactComponent.test.tsx
@@ -1,0 +1,66 @@
+import ko from "knockout";
+import React from "react";
+import { reactComponentBindingHandler } from "../../src/index";
+import { setupKoTest } from "../koTestUtils";
+
+reactComponentBindingHandler.register();
+reactComponentBindingHandler.registerShorthandSyntax();
+
+const Greeter = ({name = "World"}: {name: string}) => ( // tslint:disable-line variable-name
+    <div>Hello, {name}</div>
+);
+
+test("renders the component", () => {
+    const vm = {
+        Greeter,
+    };
+    const element = setupKoTest(`
+        <div data-bind="reactComponent: { Component: Greeter }"></div>
+    `, vm);
+    expect(element.textContent).toBe("Hello, World");
+});
+
+test("accepts props", () => {
+    const vm = {
+        Greeter,
+    };
+    const element = setupKoTest(`
+        <div data-bind="reactComponent: { Component: Greeter, props: { name: 'Mark' } }"></div>
+    `, vm);
+    expect(element.textContent).toBe("Hello, Mark");
+});
+
+test("props can be an observable", () => {
+    const vm = {
+        Greeter,
+        props: ko.observable({name: "Susan"}),
+    };
+    const element = setupKoTest(`
+        <div data-bind="reactComponent: { Component: Greeter, props: props }"></div>
+    `, vm);
+    expect(element.textContent).toBe("Hello, Susan");
+    vm.props({name: "Susie"});
+    expect(element.textContent).toBe("Hello, Susie");
+});
+test("props can contain an observable", () => {
+    const vm = {
+        Greeter,
+        props: { name: ko.observable("John") },
+    };
+    const element = setupKoTest(`
+        <div data-bind="reactComponent: { Component: Greeter, props: props }"></div>
+    `, vm);
+    expect(element.textContent).toBe("Hello, John");
+    vm.props.name("Jonny");
+    expect(element.textContent).toBe("Hello, Jonny");
+});
+
+test("renders the component with shorthand notation", () => {
+    const vm = {
+        Greeter,
+    };
+    const element = setupKoTest(`
+        <div><!-- react: Greeter {name: "Joe"} --></div>
+    `, vm);
+    expect(element.textContent).toBe("Hello, Joe");
+});

--- a/tests/koTestUtils.ts
+++ b/tests/koTestUtils.ts
@@ -1,0 +1,14 @@
+import ko from "knockout";
+
+export const setupKoTest = (html: string, viewModel: object) => {
+    const div = document.createElement("div");
+    div.innerHTML = html.trim();
+    if(div.childNodes.length !== 1) {
+        throw new Error("Parsed HTML had multiple root elements (or no root element)");
+    }
+    const element = div.children[0] as HTMLElement;
+
+    window.document.body.appendChild(element);
+    ko.applyBindings(viewModel, element);
+    return element;
+};


### PR DESCRIPTION
Adds the `reactComponent` bindingHandler to this codebase, rather than leaving it to be implemented by the consumers.  A few tweaks from the version in our codebase; namely `params` has been renamed to `props`, since that's a much more idiomatic name.