### PR TITLE
POC: Hooks API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,29 +62,35 @@
       "dev": true
     },
     "@types/knockout": {
-      "version": "3.4.59",
-      "resolved": "https://registry.npmjs.org/@types/knockout/-/knockout-3.4.59.tgz",
-      "integrity": "sha512-uLVb9AWPnQajGE8QETNVS2qPpxTVzsWOWP9dLwBrqfIkatR3mCOoU3QP8idI4YDwRRxdTlYgfSeMFbUOjENvyw=="
+      "version": "3.4.63",
+      "resolved": "https://registry.npmjs.org/@types/knockout/-/knockout-3.4.63.tgz",
+      "integrity": "sha512-HMxBhdSwY7O/9YDs02aPXa0KkPq0fPFLmNyM4sRt1ET5qULgmzMfYF0twEhTHHZt66HvXZccYLzfO+DqxeXhNg=="
     },
     "@types/node": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.0.tgz?dl=https://registry.npmjs.org/@types/node/-/node-10.0.0.tgz",
-      "integrity": "sha1-xA+OB9zmB9PvJaYmuTpqfNz5eIE="
+      "integrity": "sha1-xA+OB9zmB9PvJaYmuTpqfNz5eIE=",
+      "dev": true
+    },
+    "@types/prop-types": {
+      "version": "15.5.8",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.8.tgz",
+      "integrity": "sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw=="
     },
     "@types/react": {
-      "version": "16.3.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.10.tgz",
-      "integrity": "sha1-LyXu+D98f2xRzqTAJmD3J8ddOzM=",
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.2.tgz",
+      "integrity": "sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==",
       "requires": {
+        "@types/prop-types": "*",
         "csstype": "^2.2.0"
       }
     },
     "@types/react-dom": {
-      "version": "16.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.9.tgz",
-      "integrity": "sha512-4Z0bW+75zeQgsEg7RaNuS1k9MKhci7oQqZXxrV5KUGIyXZHHAAL3KA4rjhdH8o6foZ5xsRMSqkoM5A3yRVPR5w==",
+      "version": "16.8.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.0.tgz",
+      "integrity": "sha512-Jp4ufcEEjVJEB0OHq2MCZcE1u3KYUKO6WnSuiU/tZeYeiZxUoQavfa/TZeiIT+1XoN6l0lQVNM30VINZFDeolQ==",
       "requires": {
-        "@types/node": "*",
         "@types/react": "*"
       }
     },
@@ -492,12 +498,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz?dl=https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz?dl=https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -1387,9 +1387,9 @@
       }
     },
     "csstype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.2.0.tgz",
-      "integrity": "sha1-Flbvl1U6xTt3CQhEolMcZmDr2QI="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.2.tgz",
+      "integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -1609,15 +1609,6 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
-      }
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz?dl=https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -1941,29 +1932,6 @@
       "dev": true,
       "requires": {
         "bser": "^2.0.0"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz?dl=https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-      "dev": true,
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz?dl=https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        }
       }
     },
     "filename-regex": {
@@ -3399,16 +3367,6 @@
         "isarray": "1.0.0"
       }
     },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz?dl=https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -4519,16 +4477,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz?dl=https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5007,22 +4955,11 @@
       "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz?dl=https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "prop-types": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz?dl=https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-      "integrity": "sha1-NmREU1ZCVd3aORGR+zoSXL32VMo=",
-      "dev": true,
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
@@ -5112,34 +5049,46 @@
       }
     },
     "react": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz?dl=https://registry.npmjs.org/react/-/react-16.3.2.tgz",
-      "integrity": "sha1-/chCA5hTOh5Yhy9ZCRsnLOL5Hqk=",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.1.tgz",
+      "integrity": "sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==",
       "dev": true,
-      "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
-      }
-    },
-    "react-dom": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
-      "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.1"
       },
       "dependencies": {
-        "prop-types": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+        "scheduler": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.1.tgz",
+          "integrity": "sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==",
+          "dev": true,
           "requires": {
-            "loose-envify": "^1.3.1",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
+    "react-dom": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.1.tgz",
+      "integrity": "sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.1"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.1.tgz",
+          "integrity": "sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==",
+          "requires": {
+            "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
           }
         }
@@ -5794,6 +5743,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
       "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -5845,12 +5795,6 @@
           }
         }
       }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz?dl=https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -6780,12 +6724,6 @@
       "integrity": "sha1-XYF/m28xu4cYNfTt8AifIavmwXA=",
       "dev": true
     },
-    "ua-parser-js": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz?dl=https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha1-6exflJi57JEOeuOsYmqAXE0J7Kw=",
-      "dev": true
-    },
     "uglify-js": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
@@ -7031,12 +6969,6 @@
       "requires": {
         "iconv-lite": "0.4.19"
       }
-    },
-    "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz?dl=https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha1-3eal3zFfnTmZGqF2IYU9cguFVm8=",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "author": "Retsam19",
   "license": "ISC",
   "dependencies": {
-    "@types/knockout": "^3.4.58",
-    "@types/react": "^16.3.10",
-    "@types/react-dom": "^16.0.6",
-    "react-dom": "^16.7.0"
+    "@types/knockout": "^3.4.63",
+    "@types/react": "^16.8.2",
+    "@types/react-dom": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.10",
@@ -29,7 +29,7 @@
     "husky": "^1.3.1",
     "jest": "^22.4.3",
     "knockout": "3.x",
-    "react": "16.x",
+    "react": "^16.7.0",
     "rollup": "^0.58.2",
     "rollup-plugin-typescript2": "^0.13.0",
     "ts-jest": "^22.4.4",
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "knockout": "3.x",
-    "react": "16.x"
+    "react": "^16.7.0"
   },
   "repository": "github:Retsam/ko-react",
   "husky": {

--- a/src/hooks/useComputed.ts
+++ b/src/hooks/useComputed.ts
@@ -1,0 +1,18 @@
+import ko from "knockout";
+import { useState, useLayoutEffect } from "react";
+
+function useComputed<T>(func: () => T) {
+    const [ computed ] = useState(() => ko.pureComputed(func));
+    const [ value, setValue ] = useState(computed.peek());
+
+    // Doing useLayoutEffect so that the subscription happens synchronously with the initial render;
+    // eliminates a window in which the component and computed can go out of sync
+    useLayoutEffect(() => {
+        computed.subscribe(val => setValue(val));
+        return () => computed.dispose();
+    }, []);
+
+    return value;
+}
+
+export default useComputed;

--- a/src/hooks/useObservable.ts
+++ b/src/hooks/useObservable.ts
@@ -1,0 +1,27 @@
+import ko from "knockout";
+import { useState, useLayoutEffect } from "react";
+
+function useForceUpdate() {
+    const [incr, setIncr] = useState(0);
+    return () => setIncr(incr + 1);
+}
+
+function useObservable<T>(observable: KnockoutObservable<T>): [T, (t: T) => void];
+function useObservable<T>(observable: KnockoutReadonlyObservable<T>): [T];
+function useObservable<T>(observable: KnockoutObservable<T> | KnockoutReadonlyObservable<T>) {
+    const forceUpdate = useForceUpdate();
+    // Doing useLayoutEffect so that the subscription happens synchronously with the initial render;
+    // eliminates a window in which the observable can go out of sync with the state
+    useLayoutEffect(() => {
+        const sub = observable.subscribe(forceUpdate);
+        return () => sub.dispose();
+    }, [observable]);
+
+    const value = observable.peek();
+    if (ko.isWriteableObservable(observable)) {
+        return [value, (val: T) => observable(val)];
+    }
+    return [value];
+}
+
+export default useObservable;

--- a/tests/hooks/useComputed.test.tsx
+++ b/tests/hooks/useComputed.test.tsx
@@ -1,0 +1,47 @@
+import ko from "knockout";
+import React from "react";
+import { act } from "react-dom/test-utils";
+import useComputed from "../../src/hooks/useComputed";
+import { mount } from "../enzyme";
+
+test("can compute JSX based on observables", () => {
+    interface ComponentProps { firstName: KnockoutObservable<string>; lastName: KnockoutObservable<string>; }
+    const Component = ({firstName, lastName}: ComponentProps) => (
+        useComputed(() => (
+            <div>{firstName()} {lastName()}</div>
+        ))
+    );
+    const firstName = ko.observable("Bob");
+    const lastName = ko.observable("Ross");
+    const element = mount(<Component firstName={firstName} lastName={lastName} />);
+    expect(element.text()).toBe("Bob Ross");
+    act(() => {
+        lastName("Jones");
+    });
+    expect(element.text()).toBe("Bob Jones");
+});
+
+test("doesn't call the render or computed function unnecessarily", () => {
+    interface ComponentProps { c: KnockoutObservable<number>; }
+    let renderCount = 0;
+    let computedCount = 0;
+    const Component = ({c}: ComponentProps) => {
+        renderCount++;
+        return useComputed(() => {
+            computedCount++;
+            return (
+            <div>{c()}</div>
+            );
+        });
+    };
+    const count = ko.observable(0);
+    mount(<Component c={count} />);
+    expect(renderCount).toBe(1);
+    expect(computedCount).toBe(1);
+    act(() => {
+        count(count() + 1);
+    });
+    expect(renderCount).toBe(2);
+    expect(computedCount).toBe(2);
+
+});

--- a/tests/hooks/useObservable.test.tsx
+++ b/tests/hooks/useObservable.test.tsx
@@ -1,0 +1,86 @@
+import ko from "knockout";
+import React, { useState } from "react";
+import useObservable, { KnockoutReadonlyObservable } from "../../src/hooks/useObservable";
+import { mount } from "../enzyme";
+import { act } from "react-dom/test-utils";
+
+test("can read from an observable", () => {
+    const Component = ({text: textObservable}: { text: KnockoutObservable<string> }) => {
+        const [text] = useObservable(textObservable);
+        return <h1>{text}</h1>;
+    };
+    const text = ko.observable("Joe");
+    const element = mount(<Component text={text} />);
+    expect(element.text()).toBe("Joe");
+    act(() => {
+        text("James");
+    });
+    expect(element.text()).toBe("James");
+});
+
+test("can write to an observable", () => {
+    const Counter = ({counter}: { counter: KnockoutObservable<number> }) => {
+        const [count, setCount] = useObservable(counter);
+        return (<>
+            <div id="count">{count}</div>
+            <button id="incr" onClick={() => setCount(count + 1)}>++</button>
+        </>);
+    };
+    const counter = ko.observable(0);
+    const element = mount(<Counter counter={counter} />);
+
+    const counterValue = () => element.find("#count").text();
+
+    expect(counterValue()).toBe("0");
+    const button = element.find("button");
+    button.simulate("click");
+
+    expect(counterValue()).toBe("1");
+});
+
+test("can read from a read-only observable", () => {
+    const Component = ({text: textObservable}: { text: KnockoutReadonlyObservable<string> }) => {
+        // Type annotation so we get a compiler error if the types are wrong.
+        const array: [string] = useObservable(textObservable);
+        if (array.length !== 1) throw new Error("Unexpectedly received a setter for a readonly observable");
+        const [text] = array;
+        return <h1>{text}</h1>;
+    };
+    // Note: this isn't actually typed as readonly (circa @types/knockout#3.4.59)
+    // But it can be cast to the KnockoutReadonlyObservable type, and `ko.isWritableObservable` returns false
+    // So it has the right runtime behavior
+    const readonly = ko.computed(() => "Hello");
+    const element = mount(<Component text={readonly} />);
+    expect(element.text()).toBe("Hello");
+});
+
+test("behaves appropriately if the observable is swapped for a different observable", () => {
+    const Child = ({count}: { count: KnockoutObservable<number> }) => {
+        const [countValue] = useObservable(count);
+        return <div>{countValue}</div>;
+    };
+    let setCountObservable: React.Dispatch<React.SetStateAction<KnockoutObservable<number>>>;
+
+    const Parent = () => {
+        const [countObservable, _setCountObservable] = useState(() => ko.observable(0));
+        // Leak the setter into the enclosing scope so it can be controlled by the test
+        setCountObservable = _setCountObservable;
+        return <Child count={countObservable} />;
+    };
+    const element = mount(<Parent/>);
+    // Does it display correctly, initially?
+    expect(element.text()).toBe("0");
+
+    // Does it update when the observable is replaced?
+    const obs = ko.observable(1);
+    act(() => {
+        setCountObservable(() => obs);
+    });
+    expect(element.text()).toBe("1");
+
+    // Does it update when the new observable is changed?
+    act(() => {
+        obs(2);
+    });
+    expect(element.text()).toBe("2");
+});


### PR DESCRIPTION
This adds a hooks-based API for connecting React and knockout.  

Here's a [MobX](https://github.com/mobxjs/mobx-react-lite) version for comparison... but despite independently coming up with identically named hooks `useComputed` and `useObservable`, they're pretty different in style and implementation.  