### PR TITLE
Move react-dom to be a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "dependencies": {
     "@types/knockout": "^3.4.63",
     "@types/react": "^16.8.2",
-    "@types/react-dom": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "@types/react-dom": "^16.8.0"
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.10",
@@ -30,6 +29,7 @@
     "jest": "^22.4.3",
     "knockout": "3.x",
     "react": "^16.7.0",
+    "react-dom": "^16.8.0",
     "rollup": "^0.58.2",
     "rollup-plugin-typescript2": "^0.13.0",
     "ts-jest": "^22.4.4",
@@ -39,7 +39,8 @@
   },
   "peerDependencies": {
     "knockout": "3.x",
-    "react": "^16.7.0"
+    "react": "^16.7.0",
+    "react-dom": "^16.8.0"
   },
   "repository": "github:Retsam/ko-react",
   "husky": {


### PR DESCRIPTION
Moving `react-dom` to peer dependency, to reduce bundle size.