### PR TITLE
`useKnockoutBindings` hook and `KnockoutTemplate` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ const MessageComponent = ({text}: {text: string}) => {
 };
 ```
 
+There's some danger here about React and Knockout both trying to control the same elements: it's likely safest to not use this hook directly, but to use the provided `KnockoutTemplate` component, which wraps this hook to provide a React version of the template bindingHandler.
+
 ### Higher Order Component - `observe`
 
 A Higher Order Component which wraps a component such that any observables that are read during the render function will cause the component to rerender.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A library for allowing Knockout observables to be used with React components.  K
 
 This intended as a migration path for legacy Knockout codebases - the knockout html template engine can be replaced  with React templates, while leaving the core Knockout logic intact, allowing for an incremental migration path to React.
 
-This library provides utilities for allowing React components to rerender, driven by observables (like MobX), and a bindingHandler to bridge from ko templates to react components.  (There is not currently any provided mechanism for the reverse: rendering knockout templates from react components)
+This library provides utilities for allowing React components to rerender, driven by observables (like MobX), and a bindingHandler to bridge from ko templates to react components.  There is preliminary support for the reverse - react components to knockout logic - in the form of the `useKnockoutBindings` hook.
 
 ## API
 
@@ -53,6 +53,28 @@ const Greeter = ({firstName, lastName}: FullNameProps) => {
         </span>
     );
 }
+```
+
+#### 🚧 `useKnockoutBindings` 🚧
+
+While the rest of this library is concerned with bridging from knockout to react, this bindingHandler
+provides a mechanism for leveraging knockout nested inside of react.
+
+```tsx
+const MessageComponent = ({text}: {text: string}) => {
+    const elementRef = useRef<HTMLDivElement>(null);
+
+    const viewModel = { name: text };
+    useKnockoutBindings(elementRef, viewModel);
+
+    return (
+        // Ref of the element where knockout bindings will be applied
+        <div ref={elementRef}>
+            // Standard knockout data-binding
+            Hello, <span data-bind="text: name" />
+        </div>
+    );
+};
 ```
 
 ### Higher Order Component - `observe`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@retsam/ko-react",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retsam/ko-react",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "React bindings for Knockout",
   "main": "dist/bundle.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,6 @@ export {default as observe} from "./observe";
 export {default as useComputed} from "./hooks/useComputed";
 export {default as useObservable} from "./hooks/useObservable";
 export {default as reactComponentBindingHandler} from "./bindingHandlers/reactComponent";
+
+// React to KO
+export {default as useKnockoutBindings} from "./reactToKnockout/useKnockoutBindings";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export {default as reactComponentBindingHandler} from "./bindingHandlers/reactCo
 
 // React to KO
 export {default as useKnockoutBindings} from "./reactToKnockout/useKnockoutBindings";
+export {default as KnockoutTemplate} from "./reactToKnockout/KnockoutTemplate";

--- a/src/reactToKnockout/KnockoutTemplate.tsx
+++ b/src/reactToKnockout/KnockoutTemplate.tsx
@@ -1,0 +1,25 @@
+import React, { useRef } from 'react';
+import useKnockoutBindings from 'reactToKnockout/useKnockoutBindings';
+
+export interface KnockoutTemplateProps {
+    name: string;
+    data?: any;
+}
+const KnockoutTemplate = ({
+    name,
+    data = {},
+}: KnockoutTemplateProps) => {
+    const elRef = useRef<HTMLDivElement>(null);
+
+    useKnockoutBindings(elRef, {
+        name,
+        data,
+    });
+
+    return <div ref={elRef} data-bind="template: {
+        name: name,
+        data: data
+    }" />;
+};
+
+export default KnockoutTemplate;

--- a/src/reactToKnockout/useKnockoutBindings.ts
+++ b/src/reactToKnockout/useKnockoutBindings.ts
@@ -16,6 +16,6 @@ const useKnockoutBindings = (elementRef: RefObject<HTMLElement>, vm: any) => {
         if(!el) throw new Error("Expected to have an element in the ref");
         ko.applyBindings(vmObservable, el);
 
-    }, [elementRef]); // Maybe should be elementRef.current... but causes bindings to be reapplied
+    }, [elementRef]);
 };
 export default useKnockoutBindings;

--- a/src/reactToKnockout/useKnockoutBindings.ts
+++ b/src/reactToKnockout/useKnockoutBindings.ts
@@ -1,0 +1,21 @@
+import ko from 'knockout';
+import { RefObject, useLayoutEffect, useMemo } from "react";
+
+/**
+ * Allows knockout to be embedded inside react components.  The react component would specify
+ * a `data-bind` attribute as normal and this hook is used to apply knockout bindings to the element.
+ *
+ * NOTE: Currently expects the ref provided to be stable - it shouldn't change to a different element later
+ */
+const useKnockoutBindings = (elementRef: RefObject<HTMLElement>, vm: any) => {
+    const vmObservable = useMemo(() => ko.observable<any>(), []);
+
+    vmObservable(vm);
+    useLayoutEffect(() => {
+        const el = elementRef.current;
+        if(!el) throw new Error("Expected to have an element in the ref");
+        ko.applyBindings(vmObservable, el);
+
+    }, [elementRef]); // Maybe should be elementRef.current... but causes bindings to be reapplied
+};
+export default useKnockoutBindings;

--- a/tests/reactToKnockout/KnockoutTemplate.test.tsx
+++ b/tests/reactToKnockout/KnockoutTemplate.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import KnockoutTemplate from "../../src/reactToKnockout/KnockoutTemplate";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+
+// <script type="text/html" id="theTemplate">{templateContent}</script>
+const buildTemplateElement = (id: string, innerHTML: string) => {
+    const templateElement = document.createElement("script");
+    templateElement.type = "text/html";
+    templateElement.id = id;
+    templateElement.text = innerHTML;
+    return templateElement;
+};
+const helloWorldTemplateId = "helloWorld";
+const helloWorldTemplate = buildTemplateElement(
+    helloWorldTemplateId,
+    "Hello, World",
+);
+
+const greeterTemplateId = "greeter";
+const greeterTemplate = buildTemplateElement(
+    greeterTemplateId,
+    `Hello, <span data-bind="text: name"></span>`,
+);
+
+
+let container: HTMLDivElement;
+beforeEach(() => {
+    document.body.appendChild(helloWorldTemplate);
+    document.body.appendChild(greeterTemplate);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+afterEach(() => {
+    document.body.removeChild(helloWorldTemplate);
+    document.body.removeChild(greeterTemplate);
+    document.body.removeChild(container);
+    container = null;
+});
+
+test("Can render a template without data", () => {
+    act(() => {
+        ReactDOM.render(<KnockoutTemplate
+            name={helloWorldTemplateId}
+        />, container);
+    });
+
+    const element = container.querySelector('div');
+    expect(element.textContent).toBe('Hello, World');
+});
+
+test("Can render templates with data", () => {
+    act(() => {
+        ReactDOM.render(<KnockoutTemplate
+            name={greeterTemplateId}
+            data={{name: "Mark"}}
+        />, container);
+    });
+    const element = container.querySelector('div');
+    expect(element.textContent).toBe('Hello, Mark');
+});

--- a/tests/reactToKnockout/useKnockoutBindings.test.tsx
+++ b/tests/reactToKnockout/useKnockoutBindings.test.tsx
@@ -1,0 +1,58 @@
+import React, { useRef } from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import useKnockoutBindings from "../../src/reactToKnockout/useKnockoutBindings";
+import { mount } from "../enzyme";
+
+let container: HTMLDivElement;
+beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+});
+
+
+test("can apply knockout bindings to an element", () => {
+    const TestComponent = () => {
+        const elementRef = useRef<HTMLDivElement>(null);
+        useKnockoutBindings(elementRef, {});
+        return <div ref={elementRef} data-bind="text: 'Test'" />;
+    };
+
+    const element = mount(<TestComponent />);
+    expect(element.text()).toBe("Test");
+});
+
+test("can apply bindings to an element with data", () => {
+    const TestComponent = () => {
+        const vm = { text: 'Hello' };
+        const elementRef = useRef<HTMLDivElement>(null);
+        useKnockoutBindings(elementRef, vm);
+        return <div ref={elementRef} data-bind="text: text" />;
+    };
+
+    const element = mount(<TestComponent />);
+    expect(element.text()).toBe("Hello");
+});
+
+test("can change the data that is applied to the bindings", () => {
+    const TestComponent = (props: {text: string}) => {
+        const elementRef = useRef<HTMLDivElement>(null);
+        useKnockoutBindings(elementRef, props);
+        return <div ref={elementRef} data-bind="text: text" />;
+    };
+    act(() => {
+        ReactDOM.render(<TestComponent text="hello" />, container);
+    });
+    const element = container.querySelector('div');
+    expect(element.textContent).toBe('hello');
+
+    act(() => {
+        ReactDOM.render(<TestComponent text="there" />, container);
+    });
+    expect(element.textContent).toBe('there');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "jsx": "react",
     "moduleResolution": "node",
     "rootDir": "src",
+    "baseUrl": "src",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Adds a hook for applying bindings to a react node, and a component which uses that hook to provide a react version of the knockout `template` bindingHandler.  It's probably the best idea to just use the latter, and not directly use the former.