### PR TITLE
Fix useObservable to allow the observable to update multiple times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@retsam/ko-react",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retsam/ko-react",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "React bindings for Knockout",
   "main": "dist/bundle.js",
   "typings": "dist/index.d.ts",

--- a/src/hooks/useObservable.ts
+++ b/src/hooks/useObservable.ts
@@ -2,8 +2,9 @@ import ko from "knockout";
 import { useState, useLayoutEffect } from "react";
 
 function useForceUpdate() {
-    const [incr, setIncr] = useState(0);
-    return () => setIncr(incr + 1);
+    const [/*val*/, setIncr] = useState(0);
+    // Using callback form of setIncr so that the same useForceUpdate function can be called multiple times
+    return () => setIncr((val) => val + 1);
 }
 
 /**

--- a/tests/hooks/useObservable.test.tsx
+++ b/tests/hooks/useObservable.test.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import useObservable, { KnockoutReadonlyObservable } from "../../src/hooks/useObservable";
 import { mount } from "../enzyme";
 import { act } from "react-dom/test-utils";
+import { exact } from "prop-types";
 
 test("can read from an observable", () => {
     const Component = ({text: textObservable}: { text: KnockoutObservable<string> }) => {
@@ -16,6 +17,10 @@ test("can read from an observable", () => {
         text("James");
     });
     expect(element.text()).toBe("James");
+    act(() => {
+        text("Jack");
+    });
+    expect(element.text()).toBe("Jack");
 });
 
 test("can write to an observable", () => {


### PR DESCRIPTION
useObservable wasn't updating multiple times, due to a bug with `useForceUpdate`: since the `forceUpdate` function was capturing its value by closure, it would only trigger an update the first time it was called.  