### PR TITLE
Improve useObservable and useComputed APIs - [Breaking changes]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,14 +73,14 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.5.8",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.8.tgz",
-      "integrity": "sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw=="
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
+      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg=="
     },
     "@types/react": {
-      "version": "16.8.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.2.tgz",
-      "integrity": "sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==",
+      "version": "16.8.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.14.tgz",
+      "integrity": "sha512-26tFVJ1omGmzIdFTFmnC5zhz1GTaqCjxgUxV4KzWvsybF42P7/j4RBn6UeO3KbHPXqKWZszMXMoI65xIWm954A==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -1387,9 +1387,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.2.tgz",
-      "integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow=="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
+      "integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -4030,7 +4030,8 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz?dl=https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.11.0",
@@ -4245,6 +4246,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz?dl=https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0"
       }
@@ -4553,7 +4555,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz?dl=https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -4959,6 +4962,7 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
@@ -5076,6 +5080,7 @@
       "version": "16.8.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.1.tgz",
       "integrity": "sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -5087,6 +5092,7 @@
           "version": "0.13.1",
           "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.1.tgz",
           "integrity": "sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==",
+          "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@retsam/ko-react",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retsam/ko-react",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "React bindings for Knockout",
   "main": "dist/bundle.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/knockout": "^3.4.63",
-    "@types/react": "^16.8.2",
+    "@types/react": "^16.8.14",
     "@types/react-dom": "^16.8.0"
   },
   "devDependencies": {

--- a/src/hooks/useComputed.ts
+++ b/src/hooks/useComputed.ts
@@ -8,7 +8,7 @@ import useMemoWithDisposer from "hooks/utils/useMemoWithDisposer";
  * @param func A pure function that reads observables to produce a value,
  *      (does not need to be a ko.computed, and probably shouldn't be)
  */
-function useComputed<T>(func: () => T, deps?: any[]) {
+function useComputed<T>(func: () => T, deps: any[] | undefined) {
     const forceUpdate = useForceUpdate();
     const computed = useMemoWithDisposer(
         () => {

--- a/src/hooks/useComputed.ts
+++ b/src/hooks/useComputed.ts
@@ -1,5 +1,6 @@
 import ko from "knockout";
-import { useState, useLayoutEffect, useEffect } from "react";
+import useForceUpdate from "hooks/utils/useForceUpdate";
+import useMemoWithDisposer from "hooks/utils/useMemoWithDisposer";
 
 /**
  * Returns the result of a provided function, causing a rerender whenever
@@ -7,28 +8,18 @@ import { useState, useLayoutEffect, useEffect } from "react";
  * @param func A pure function that reads observables to produce a value,
  *      (does not need to be a ko.computed, and probably shouldn't be)
  */
-function useComputed<T>(func: () => T, deps: any[] = []) {
-    // The func is put in an observable, so that it can be changed
-    //  whenever dependencies (e.g. closure variables used by func) change
-    const [ funcObservable ] = useState(() => ko.observable(func));
-    const [ computed ] = useState(() => ko.pureComputed(() => (
-        funcObservable()()
-    )));
-    const [ value, setValue ] = useState(computed.peek());
-
-    // Doing useLayoutEffect so that the subscription happens synchronously with the initial render;
-    // eliminates a window in which the component and computed can go out of sync
-    useLayoutEffect(() => {
-        computed.subscribe(val => setValue(val));
-        return () => computed.dispose();
-    }, []);
-
-    // When deps change, replace the function
-    useEffect(() => {
-        funcObservable(func);
-    }, deps);
-
-    return value;
+function useComputed<T>(func: () => T, deps?: any[]) {
+    const forceUpdate = useForceUpdate();
+    const computed = useMemoWithDisposer(
+        () => {
+            const c = ko.pureComputed(func);
+            c.subscribe(forceUpdate);
+            return c;
+        },
+        (computed) => computed.dispose(),
+        deps,
+    );
+    return computed();
 }
 
 export default useComputed;

--- a/src/hooks/useObservable.ts
+++ b/src/hooks/useObservable.ts
@@ -1,4 +1,3 @@
-import ko from "knockout";
 import { useState, useLayoutEffect } from "react";
 
 function useForceUpdate() {
@@ -11,9 +10,7 @@ function useForceUpdate() {
  * Reads and subscribes to the value of a single observable,
  *  triggering a rerender if the value inside the observable changes
  */
-function useObservable<T>(observable: KnockoutObservable<T>): [T, (t: T) => void];
-function useObservable<T>(observable: KnockoutReadonlyObservable<T>): [T];
-function useObservable<T>(observable: KnockoutObservable<T> | KnockoutReadonlyObservable<T>) {
+function useObservable<T>(observable: KnockoutObservable<T>) {
     const forceUpdate = useForceUpdate();
     // Doing useLayoutEffect so that the subscription happens synchronously with the initial render;
     // eliminates a window in which the observable can go out of sync with the state
@@ -22,11 +19,7 @@ function useObservable<T>(observable: KnockoutObservable<T> | KnockoutReadonlyOb
         return () => sub.dispose();
     }, [observable]);
 
-    const value = observable.peek();
-    if (ko.isWriteableObservable(observable)) {
-        return [value, (val: T) => observable(val)];
-    }
-    return [value];
+    return observable.peek();
 }
 
 export default useObservable;

--- a/src/hooks/utils/useForceUpdate.ts
+++ b/src/hooks/utils/useForceUpdate.ts
@@ -1,0 +1,8 @@
+import { useState } from "react";
+
+/** Returns a function that can be called to force the component to rerender */
+export default function useForceUpdate() {
+    const [/*val*/, setIncr] = useState(0);
+    // Using callback form of setIncr so that the same useForceUpdate function can be called multiple times
+    return () => setIncr((val) => val + 1);
+}

--- a/src/hooks/utils/useMemoWithDisposer.ts
+++ b/src/hooks/utils/useMemoWithDisposer.ts
@@ -1,0 +1,19 @@
+import { useMemo, useRef, useEffect } from "react";
+
+// Like useMemo, but calls `disposer` on the previously memoized values when they're replaced
+export default function useMemoWithDisposer<T>(
+    memoizer: () => T,
+    disposer: (t: T) => void,
+    deps: any[] | undefined,
+) {
+    // Stores the previous value so that it can be disposed
+    const memoizedVal = useRef<T | undefined>(undefined);
+
+    // Dispose the last value on unmount
+    useEffect(() => () => disposer(memoizedVal.current!), []);
+
+    return useMemo(() => {
+        if(memoizedVal.current) { disposer(memoizedVal.current); }
+        return memoizedVal.current = memoizer();
+    }, deps);
+}

--- a/tests/hooks/useComputed.test.tsx
+++ b/tests/hooks/useComputed.test.tsx
@@ -32,7 +32,7 @@ test("doesn't call the render or computed function unnecessarily", () => {
             return (
             <div>{c()}</div>
             );
-        });
+        }, []);
     };
     const count = ko.observable(0);
     mount(<Component c={count} />);
@@ -43,20 +43,53 @@ test("doesn't call the render or computed function unnecessarily", () => {
     });
     expect(renderCount).toBe(2);
     expect(computedCount).toBe(2);
-
 });
 
-test("can be used with non-observable state" , () => {
+test("can be used with closure values" , () => {
     const Counter = () => {
         const [count, setCount] = useState(0);
+        // NOT passing a dependency array: behaves correctly, but may compute more often than necessary
         return useComputed(() => (
             <div onClick={() => setCount(count + 1)}>Value is {count}</div>
-        ), [count]);
+        ));
     };
     const element = mount(<Counter />);
     act(() => {
         element.simulate('click');
     });
     expect(element.text()).toBe("Value is 1");
+});
 
-})
+test("doesn't call the render or computed function unnecessarily with deps", () => {
+    let renderCount = 0;
+    let computedCount = 0;
+    const Counter = ({plus}: {plus: KnockoutObservable<number>}) => {
+        renderCount++;
+        const [count, setCount] = useState(0);
+        return useComputed(() => (
+            computedCount++,
+            <div onClick={() => setCount(count + 1)}>Value is {count + plus()}</div>
+        ), [count]);
+    };
+    const plus = ko.observable(0);
+    const element = mount(<Counter plus={plus} />);
+    expect(renderCount).toBe(1);
+    expect(computedCount).toBe(1);
+    expect(element.text()).toBe("Value is 0");
+
+    // Update observable state
+    act(() => {
+        plus(2);
+    });
+    expect(renderCount).toBe(2);
+    expect(computedCount).toBe(2);
+    expect(element.text()).toBe("Value is 2");
+
+    // Update non-observable state
+    act(() => {
+        element.simulate('click');
+    });
+    expect(renderCount).toBe(3);
+    expect(computedCount).toBe(3);
+    expect(element.text()).toBe("Value is 3");
+});

--- a/tests/hooks/useObservable.test.tsx
+++ b/tests/hooks/useObservable.test.tsx
@@ -1,13 +1,12 @@
 import ko from "knockout";
 import React, { useState } from "react";
-import useObservable, { KnockoutReadonlyObservable } from "../../src/hooks/useObservable";
+import useObservable from "../../src/hooks/useObservable";
 import { mount } from "../enzyme";
 import { act } from "react-dom/test-utils";
-import { exact } from "prop-types";
 
 test("can read from an observable", () => {
     const Component = ({text: textObservable}: { text: KnockoutObservable<string> }) => {
-        const [text] = useObservable(textObservable);
+        const text = useObservable(textObservable);
         return <h1>{text}</h1>;
     };
     const text = ko.observable("Joe");
@@ -23,45 +22,9 @@ test("can read from an observable", () => {
     expect(element.text()).toBe("Jack");
 });
 
-test("can write to an observable", () => {
-    const Counter = ({counter}: { counter: KnockoutObservable<number> }) => {
-        const [count, setCount] = useObservable(counter);
-        return (<>
-            <div id="count">{count}</div>
-            <button id="incr" onClick={() => setCount(count + 1)}>++</button>
-        </>);
-    };
-    const counter = ko.observable(0);
-    const element = mount(<Counter counter={counter} />);
-
-    const counterValue = () => element.find("#count").text();
-
-    expect(counterValue()).toBe("0");
-    const button = element.find("button");
-    button.simulate("click");
-
-    expect(counterValue()).toBe("1");
-});
-
-test("can read from a read-only observable", () => {
-    const Component = ({text: textObservable}: { text: KnockoutReadonlyObservable<string> }) => {
-        // Type annotation so we get a compiler error if the types are wrong.
-        const array: [string] = useObservable(textObservable);
-        if (array.length !== 1) throw new Error("Unexpectedly received a setter for a readonly observable");
-        const [text] = array;
-        return <h1>{text}</h1>;
-    };
-    // Note: this isn't actually typed as readonly (circa @types/knockout#3.4.59)
-    // But it can be cast to the KnockoutReadonlyObservable type, and `ko.isWritableObservable` returns false
-    // So it has the right runtime behavior
-    const readonly = ko.computed(() => "Hello");
-    const element = mount(<Component text={readonly} />);
-    expect(element.text()).toBe("Hello");
-});
-
 test("behaves appropriately if the observable is swapped for a different observable", () => {
     const Child = ({count}: { count: KnockoutObservable<number> }) => {
-        const [countValue] = useObservable(count);
+        const countValue = useObservable(count);
         return <div>{countValue}</div>;
     };
     let setCountObservable: React.Dispatch<React.SetStateAction<KnockoutObservable<number>>>;

--- a/tests/hooks/utils/useMemoWithDisposer.test.tsx
+++ b/tests/hooks/utils/useMemoWithDisposer.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+// import { act } from "react-dom/test-utils";
+import useMemoWithDisposer from "../../../src/hooks/utils/useMemoWithDisposer";
+import { mount } from "../../enzyme";
+
+test("memoizes values", () => {
+    const memoizedFunc = jest.fn();
+    type TestProps = Record<"a" | "b", number>;
+    const TestComponent = ({a}: TestProps) => {
+        useMemoWithDisposer(
+            memoizedFunc,
+            () => {/*dispose*/},
+            [a],
+        );
+        return <div></div>;
+    };
+    const com = mount(<TestComponent a={1} b={2} />);
+    expect(memoizedFunc).toHaveBeenCalledTimes(1);
+    // Change memoized prop
+    com.setProps({a: 2});
+    expect(memoizedFunc).toHaveBeenCalledTimes(2);
+    // Change non-memoized prop
+    com.setProps({b: 2});
+    expect(memoizedFunc).toHaveBeenCalledTimes(2);
+});
+
+test("disposes previously memoized values", () => {
+    const disposerFunc = jest.fn();
+    type TestProps = Record<"a", string>;
+    const TestComponent = ({a}: TestProps) => {
+        useMemoWithDisposer(
+            () => a,
+            disposerFunc,
+            [a],
+        );
+        return <div></div>;
+    };
+    const com = mount(<TestComponent a={"Initial value"} />);
+    expect(disposerFunc).not.toHaveBeenCalled();
+
+    com.setProps({a: "New val"});
+    expect(disposerFunc).toHaveBeenCalledWith("Initial value");
+
+    com.setProps({a: 3});
+    expect(disposerFunc).toHaveBeenCalledWith("New val");
+    expect(disposerFunc).toHaveBeenCalledTimes(2);
+});
+
+test("disposes last memoized value on unmount", () => {
+    const disposerFunc = jest.fn();
+    type TestProps = Record<"a", string>;
+    const TestComponent = ({a}: TestProps) => {
+        useMemoWithDisposer(
+            () => a,
+            disposerFunc,
+            [a],
+        );
+        return <div></div>;
+    };
+    const com = mount(<TestComponent a={"Initial value"} />);
+    expect(disposerFunc).not.toHaveBeenCalled();
+
+    com.unmount();
+    expect(disposerFunc).toHaveBeenCalledTimes(1);
+    expect(disposerFunc).toHaveBeenCalledWith("Initial value");
+});


### PR DESCRIPTION
* `useObservable` now just returns the unwrapped value, rather than returning a `[value, setValue]` tuple.  If you want to change the observable, just write to the observable as normal.

* `useComputed` - deps now defaults to `undefined` not `[]`.  Now if `deps` aren't provided, it will recalculate the computed every time, rather than returning an memoized value based on previous closure variables.  (This exposed some issues with the current implementation, so it was reimplemented)

Following the current practices of the hook typings, the second argument to `useComputed` is not optional, but can be passed explicitly as `undefined`.