### PR TITLE
Add useSubscription hook

### DIFF
--- a/src/hooks/useObservable.ts
+++ b/src/hooks/useObservable.ts
@@ -1,10 +1,5 @@
-import { useState, useLayoutEffect } from "react";
-
-function useForceUpdate() {
-    const [/*val*/, setIncr] = useState(0);
-    // Using callback form of setIncr so that the same useForceUpdate function can be called multiple times
-    return () => setIncr((val) => val + 1);
-}
+import useSubscription from "hooks/useSubscription";
+import useForceUpdate from "hooks/utils/useForceUpdate";
 
 // Building this type so that this hook can be used with computeds, or observables that have been
 //  cast to be readonly
@@ -15,13 +10,7 @@ export type ReadonlyObservable<T> = Pick<KnockoutObservable<T>, "subscribe" | "p
  *  triggering a rerender if the value inside the observable changes
  */
 function useObservable<T>(observable: ReadonlyObservable<T>) {
-    const forceUpdate = useForceUpdate();
-    // Doing useLayoutEffect so that the subscription happens synchronously with the initial render;
-    // eliminates a window in which the observable can go out of sync with the state
-    useLayoutEffect(() => {
-        const sub = observable.subscribe(forceUpdate);
-        return () => sub.dispose();
-    }, [observable]);
+    useSubscription(observable, useForceUpdate());
 
     return observable.peek();
 }

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -1,0 +1,24 @@
+import { useRef, useLayoutEffect } from "react";
+
+/**
+ * Executes the provided callback function whenever the observable changes its value
+ */
+function useSubscription<T>(
+    observable: Pick<KnockoutSubscribable<T>, "subscribe">,
+    callback: (t: T) => void,
+) {
+    // By storing the callback in a ref and updating it every render,
+    //  we always call the newest version of the callback, avoiding any
+    //  stale closure reference issues (without needing a deps array)
+    const callbackRef = useRef(callback);
+    callbackRef.current = callback;
+
+    // Doing useLayoutEffect so that the subscription happens synchronously with the initial render;
+    // eliminates a window in which the observable can change without triggering the subscription
+    useLayoutEffect(() => {
+        const sub = observable.subscribe(t => callbackRef.current(t));
+        return () => sub.dispose();
+    }, [observable]);
+}
+
+export default useSubscription;

--- a/src/hooks/utils/useForceUpdate.ts
+++ b/src/hooks/utils/useForceUpdate.ts
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 /** Returns a function that can be called to force the component to rerender */
 export default function useForceUpdate() {
-    const [/*val*/, setIncr] = useState(0);
-    // Using callback form of setIncr so that the same useForceUpdate function can be called multiple times
-    return () => setIncr((val) => val + 1);
+    const [/*val*/, setVal] = useState(0);
+    // Using callback form of setVal so that the same useForceUpdate function can be called multiple times
+    return () => setVal(val => val + 1);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export {default as observe} from "./observe";
 export {default as useComputed} from "./hooks/useComputed";
 export {default as useObservable} from "./hooks/useObservable";
+export {default as useSubscription} from "./hooks/useSubscription";
 export {default as reactComponentBindingHandler} from "./bindingHandlers/reactComponent";
 
 // React to KO

--- a/tests/hooks/useSubscription.test.tsx
+++ b/tests/hooks/useSubscription.test.tsx
@@ -1,0 +1,121 @@
+import ko from "knockout";
+import React from "react";
+import useSubscription from "../../src/hooks/useSubscription";
+import { mount } from "../enzyme";
+
+test("executes the callback whenever the subscription is fired", () => {
+    // ko.subscribable is the supertype of observables and computeds
+    const subscribable = new ko.subscribable<string>();
+    const callbackFn = jest.fn();
+    const Component = () => {
+        useSubscription(subscribable, callbackFn);
+
+        return <></>;
+    };
+    mount(<Component />);
+
+    expect(callbackFn).not.toHaveBeenCalled();
+
+    subscribable.notifySubscribers("Foo");
+    expect(callbackFn).toHaveBeenCalledTimes(1);
+    expect(callbackFn).toHaveBeenCalledWith("Foo");
+
+    subscribable.notifySubscribers("Bar");
+    expect(callbackFn).toHaveBeenCalledTimes(2);
+    expect(callbackFn).toHaveBeenCalledWith("Bar");
+});
+
+test("does not cause additional renders when the observable changes", () => {
+    const subscribable = new ko.subscribable<string>();
+    const renderSpy = jest.fn();
+    const callbackFn = jest.fn();
+
+    const Component = () => {
+        renderSpy();
+        subscribable.subscribe(callbackFn);
+        return <></>;
+    };
+
+    mount(<Component />);
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+
+    subscribable.notifySubscribers("Foo");
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+});
+
+test("correctly handles closure state inside callbacks", () => {
+    const callbackFn = jest.fn();
+    const subscribable = new ko.subscribable<string>();
+
+    const Component = ({prop}: {prop: string}) => {
+        useSubscription(subscribable, (value) => {
+            // Passes the current value of prop to the callback
+            callbackFn(`${value} ${prop}`);
+        });
+        return <></>;
+    };
+    const element = mount(<Component prop={"initial"} />);
+
+    subscribable.notifySubscribers("foo");
+    expect(callbackFn).toHaveBeenCalledTimes(1);
+    expect(callbackFn).toHaveBeenCalledWith("foo initial");
+
+    element.setProps({prop: "updated"});
+
+    subscribable.notifySubscribers("bar");
+    expect(callbackFn).toHaveBeenCalledTimes(2);
+    expect(callbackFn).toHaveBeenCalledWith("bar updated");
+});
+
+test("correctly handles the observable being changed", () => {
+    const callbackFn = jest.fn();
+
+    const Component = ({sub}: { sub: KnockoutSubscribable<void>; }) => {
+        useSubscription(sub, callbackFn);
+        return <></>;
+    };
+
+    const sub1 = new ko.subscribable<void>();
+    const sub2 = new ko.subscribable<void>();
+
+    const element = mount(<Component sub={sub1} />);
+
+    // Triggeres the callback
+    sub1.notifySubscribers();
+    expect(callbackFn).toHaveBeenCalledTimes(1);
+
+    // Does not trigger the callback
+    sub2.notifySubscribers();
+    expect(callbackFn).toHaveBeenCalledTimes(1);
+
+    // Swap the subscribable
+    element.setProps({sub: sub2});
+
+    // Does not trigger the callback
+    sub1.notifySubscribers();
+    expect(callbackFn).toHaveBeenCalledTimes(1);
+
+    // Triggers the callback
+    sub2.notifySubscribers();
+    expect(callbackFn).toHaveBeenCalledTimes(2);
+});
+
+test("disposes the subscription when the component is unmounted", () => {
+    const subscribable = new ko.subscribable<string>();
+    const callbackFn = jest.fn();
+    const Component = () => {
+        useSubscription(subscribable, callbackFn);
+
+        return <></>;
+    };
+    const element = mount(<Component />);
+
+    subscribable.notifySubscribers("Foo");
+    expect(callbackFn).toHaveBeenCalledTimes(1);
+    expect(callbackFn).toHaveBeenCalledWith("Foo");
+
+    element.unmount();
+
+    subscribable.notifySubscribers("Bar");
+    expect(callbackFn).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
Adds a third hook - `useSubscription`, which sets up a subscription on an observable or computed, and disposes it when the component unmounts and handles the observable being swapped out, etc.

Unlike using `useComputed` or `useObserve`, the subscription firing will not cause renders.  (Unless the callback function modifies component state.)