### PR TITLE
Fix issue with unnecessary re-renders by reactComponent bindingHandler

### DIFF
--- a/src/bindingHandlers/reactComponent.ts
+++ b/src/bindingHandlers/reactComponent.ts
@@ -22,7 +22,17 @@ const bindingHandler: KnockoutBindingHandler<HTMLElement, ReactComponentBindingV
         if(!Component) {
             throw new Error("No component provided to reactComponent bindingHandler");
         }
-        ReactDOM.render(React.createElement(Component, ko.unwrap(props) || ko.unwrap(params)), element); // props || params for backwards compatibility
+        // The whole props could be an observable
+        // props || params for backwards compatibility
+        const unwrappedProps = ko.unwrap(props) || ko.unwrap(params);
+        // Ignore dependencies to avoid unwanted subscriptions to observables
+        //   inside render functions
+        ko.ignoreDependencies(() =>
+            ReactDOM.render(
+                React.createElement(Component, unwrappedProps),
+                element,
+            ),
+        );
     },
 };
 

--- a/tests/bindingHandlers/reactComponent.test.tsx
+++ b/tests/bindingHandlers/reactComponent.test.tsx
@@ -65,7 +65,9 @@ test("props can contain an observable", () => {
     `, vm);
     expect(element.textContent).toBe("Hello, John");
     vm.props.name("Jonny");
-    expect(element.textContent).toBe("Hello, Jonny");
+    // Still John, because changing observables only causes rerenders if
+    //   wrapped in useObserve, useComputed, etc.
+    expect(element.textContent).toBe("Hello, John");
 });
 
 test("renders the component with shorthand notation", () => {


### PR DESCRIPTION
The old version was calling `React.createElement` inside a computed context (the `update` function is implicitly wrapped in a computed by knockout) - this meant that unwanted subscriptions were being made to observables inside the render function.

I had a unit test on this case, but the unit test was actually verifying the wrong behavior.  Oops.  