### PR TITLE
Wrap the vm update in useLayoutEffect to avoid side-effects

### DIFF
--- a/src/reactToKnockout/useKnockoutBindings.ts
+++ b/src/reactToKnockout/useKnockoutBindings.ts
@@ -10,7 +10,10 @@ import { RefObject, useLayoutEffect, useMemo } from "react";
 const useKnockoutBindings = (elementRef: RefObject<HTMLElement>, vm: any) => {
     const vmObservable = useMemo(() => ko.observable<any>(), []);
 
-    vmObservable(vm);
+    // Set (or update) the vm;
+    // with useLayoutEffect to avoid side-effects in the render function
+    useLayoutEffect(() => { vmObservable(vm); }, [vm]);
+    // Apply bindings
     useLayoutEffect(() => {
         const el = elementRef.current;
         if(!el) throw new Error("Expected to have an element in the ref");


### PR DESCRIPTION
Previously `useKnockoutBindings` was updating the `viewModel` observable in the render function.  In some cases (specifically, "React > Knockout > React") this was causing React warnings about side-effects in render functions. 

So wrapping the viewModel updating logic in a `useEffect` call to avoid that warning.  