### PR TITLE
Handle rate-limited observable case

### DIFF
--- a/src/hooks/useObservable.ts
+++ b/src/hooks/useObservable.ts
@@ -12,7 +12,9 @@ export type ReadonlyObservable<T> = Pick<KnockoutObservable<T>, "subscribe" | "p
 function useObservable<T>(observable: ReadonlyObservable<T>) {
     useSubscription(observable, useForceUpdate());
 
-    return observable.peek();
+    // Passing undocument `true` option to `observable.peek` to force it to read the latest value
+    // from the observable, even if it's been rate-limited.
+    return observable.peek(...[true] as any as []);
 }
 
 export default useObservable;

--- a/tests/hooks/useObservable.test.tsx
+++ b/tests/hooks/useObservable.test.tsx
@@ -22,6 +22,25 @@ test("can read from an observable", () => {
     expect(element.text()).toBe("Jack");
 });
 
+test("can read from a computed", () => {
+    const Component = ({text: textComputed}: { text: KnockoutComputed<string> }) => {
+        const text = useObservable(textComputed);
+        return <h1>{text}</h1>;
+    };
+    const firstName = ko.observable("Joe");
+    const lastName = ko.observable("Smith");
+    const fullName = ko.computed(() => `${firstName()} ${lastName()}`);
+
+    const element = mount(<Component text={fullName} />);
+
+    expect(element.text()).toBe("Joe Smith");
+
+    act(() => {
+        lastName("Danger");
+    });
+    expect(element.text()).toBe("Joe Danger");
+});
+
 test("behaves appropriately if the observable is swapped for a different observable", () => {
     const Child = ({count}: { count: KnockoutObservable<number> }) => {
         const countValue = useObservable(count);

--- a/tests/hooks/useObservable.test.tsx
+++ b/tests/hooks/useObservable.test.tsx
@@ -52,3 +52,20 @@ test("behaves appropriately if the observable is swapped for a different observa
     });
     expect(element.text()).toBe("2");
 });
+
+test("handles rateLimited computeds", () => {
+    const obs = ko.observable(1);
+
+    const rateLimited = ko.computed(() => {
+        return obs() + 1;
+    }).extend({rateLimit: 1000});
+
+    const Component = () => {
+        // Should force `rateLimited` to read the new value, despite the `rateLimit`.
+        const value = useObservable(rateLimited);
+        return <div>{value}</div>;
+    };
+    obs(2);
+    const element = mount(<Component/>);
+    expect(element.text()).toBe("3");
+});


### PR DESCRIPTION
Ran into an edge case where components weren't updating when reading rate-limited observables that had just been updated.  

Uses an undocumented API to ensure that it always gets the latest version of the observable.  This might be somewhat undermine the purpose of rate-limiting, but it seems fairly reasonable.