### PR TITLE
fixed useObservable documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ interface FullNameProps {
 
 // Re-renders only if firstName changes
 const Greeter = ({firstName, lastName}: FullNameProps) => {
-    const [fName] = useObservable(firstName)
+    const fName = useObservable(firstName)
     return (
         <span>
             Hello, {fName} {lastName()}


### PR DESCRIPTION
The documentation made it look like useObservable was returning an array (similar to hooks), but it doesn't. It returns the actual value of the observable, so the example in the documentation would actually only display the first letter from the firstName.