### PR TITLE
Modify peerDependency so react 17 is officially supported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@retsam/ko-react",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   },
   "peerDependencies": {
     "knockout": "3.x",
-    "react": "^16.7.0",
-    "react-dom": "^16.8.0"
+    "react": "16 - 17",
+    "react-dom": "16 - 17"
   },
   "repository": "github:Retsam/ko-react",
   "husky": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retsam/ko-react",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "React bindings for Knockout",
   "main": "dist/bundle.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
No actual changes - this uses so little of the React API I'd be very surprised if React 17 breaks anything.